### PR TITLE
Ignore bundled Ruby gems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ _site
 .jekyll-metadata
 .bundle
 .sass-cache
+/vendor/bundle/
 Gemfile
 Gemfile.lock
 node_modules


### PR DESCRIPTION
Adds a .gitignore rule so Bundler vendored gems under vendor/bundle are not included in commits.